### PR TITLE
Dev setup on non native linux systems

### DIFF
--- a/hunt-vagrant/Vagrantfile
+++ b/hunt-vagrant/Vagrantfile
@@ -1,0 +1,26 @@
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.23.2"
+
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+
+  config.vm.synced_folder "..", "/hunt"
+
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  config.vm.provision "shell", path: "bootstrap.sh"
+
+end

--- a/hunt-vagrant/bootstrap.sh
+++ b/hunt-vagrant/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y python-software-properties
+add-apt-repository -y ppa:hvr/ghc
+apt-get update
+apt-get install -y git build-essential ghc-7.8.2 cabal-install-1.20 zlib1g-dev libbz2-dev libsnappy-dev
+
+P="/opt/cabal/1.20/bin:/opt/ghc/7.8.2/bin:$PATH"
+
+export PATH="$P"
+echo "export PATH='$P'" >> /home/vagrant/.bashrc
+echo "export PATH='$P'" >> /home/vagrant/.profile
+
+cabal update && cd /hunt/ && make install


### PR DESCRIPTION
Hi! I'm on a Windows box at work and got curious about your work. Since ghc doesn't seem to be a first-class citizen on Win (and considering the dependencies to libzilib and libsnappy) I wrote a quick Vagrantfile to setup a development environment with Vagrant. This enables Windows and Mac users to contribute without directly installing the Haskell-Platform and your required packages.

To initialize the env use `cd hunt-vagrant && vagrant up`. This will install ghc, cabal etc. in the vm and forwards port 3000 to 3000 on your host machine. The project folder is shared to /hunt. Just do 

```
vagrant ssh
cd /hunt
make ... 
```

Maybe it's useful to you considering you want to share the package on hackage someday.
